### PR TITLE
relayout fixed columns on drag

### DIFF
--- a/Source/dataTables.colResize.js
+++ b/Source/dataTables.colResize.js
@@ -868,7 +868,17 @@
                     footCol.width(thWidth);
                 }
             }
+
+            this.resizeFixedColumns();
+
             return true;
+        };
+
+        ColResize.prototype.resizeFixedColumns = function() {
+            var fc = this.dt.api.fixedColumns();
+            if (fc) {
+                fc.relayout();
+            }
         };
 
         ColResize.prototype.onMouseMove = function (e, col) {


### PR DESCRIPTION
In Firefox and IE, all columns change size on drag. When this happens with fixed columns, the fixed columns go out of alignment with the underlying table and need to have a call to `fixedColumns().relayout()` to set them straight.
